### PR TITLE
Fix frontend auth flow and cleanup configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Navigate to the frontend directory: cd user-management-frontend
 
 Install dependencies: npm install
 
+Create a `.env` file in the frontend root and define the following variables:
+```
+NEXT_PUBLIC_API_URL=http://localhost:5000
+NEXT_PUBLIC_SUPABASE_KEY=your_supabase_key
+NEXTAUTH_SECRET=some_secret
+```
+
 Create a .env file in the root directory with your NextAuth or Supabase Auth credentials.
 
 Start the Next.js application: npm run dev

--- a/user-management-frontend/postcss.config.mjs
+++ b/user-management-frontend/postcss.config.mjs
@@ -1,8 +1,0 @@
-/** @type {import('postcss-load-config').Config} */
-const config = {
-  plugins: {
-    tailwindcss: {},
-  },
-};
-
-export default config;

--- a/user-management-frontend/src/components/AdminRoute.tsx
+++ b/user-management-frontend/src/components/AdminRoute.tsx
@@ -1,5 +1,5 @@
 
-import { useSession } from "next-auth/react";
+import { useSession, signIn } from "next-auth/react";
 import { useRouter } from "next/router";
 import { ReactNode } from "react";
 
@@ -16,7 +16,7 @@ const AdminRoute = ({ children }: AdminRouteProps) => {
   }
 
   if (session?.user.role !== "admin") {
-    router.push("/auth/signin"); 
+    signIn();
     return null;
   }
 

--- a/user-management-frontend/src/pages/api/auth/[...nextauth].ts
+++ b/user-management-frontend/src/pages/api/auth/[...nextauth].ts
@@ -16,23 +16,14 @@ export default NextAuth({
         email: { label: "Email", type: "text" },
         password: { label: "Password", type: "password" },
       },
-      async authorize(credentials, req) {
+      async authorize(credentials) {
         if (!credentials) return null;
-      
-        const users = [
-          { id: "1", name: "Admin", email: "admin@example.com", role: "admin" },
-          { id: "2", name: "User", email: "user@example.com", role: "user" },
-        ];
-      
-        console.log('Credentials received:', credentials); // Add this line
+
         const user = users.find((u) => u.email === credentials.email);
-      
-        if (!user) {
-          console.log('User not found'); 
+        if (!user || user.password !== credentials.password) {
           return null;
         }
-      
-        console.log('User authorized:', user); 
+
         return {
           id: user.id,
           name: user.name,

--- a/user-management-frontend/src/services/apiService.ts
+++ b/user-management-frontend/src/services/apiService.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
-const SUPABASE_KEY = process.env.NEXT_PUBLIC_SUPABASE_KEY; 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+const SUPABASE_KEY = process.env.NEXT_PUBLIC_SUPABASE_KEY || "";
 
 export const api = axios.create({
   baseURL: API_URL,

--- a/user-management-frontend/tailwind.config.js
+++ b/user-management-frontend/tailwind.config.js
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-    content: ["./src/**/*.{js,ts,jsx,tsx}"],
-    theme: {
-        extend: {},
-    },
-    plugins: [],
-};


### PR DESCRIPTION
## Summary
- update README with frontend env vars
- clean up AdminRoute login redirect logic
- simplify CredentialsProvider authorize callback
- provide API URL fallback in frontend API client
- remove duplicate Tailwind/PostCSS configs

## Testing
- `npm test` in `user-management-backend` *(fails: no test specified)*
- `npm test` in `user-management-frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683dbb128288832da677aaaa1ae5bf5d